### PR TITLE
icon picker scroll adjustment

### DIFF
--- a/bmButtonHandlers.lua
+++ b/bmButtonHandlers.lua
@@ -209,7 +209,8 @@ function BMButtonHandlers.RenderButtonLabel(Button, cursorScreenPos, size, label
 end
 
 ---@param Button table # BMButtonConfig
-function BMButtonHandlers.ResolveButtonLabel(Button)
+---@param leaveSpaces boolean? # leave spaces or replace with new line.
+function BMButtonHandlers.ResolveButtonLabel(Button, leaveSpaces)
     local success = true
     local evaluatedLabel = Button.Label
 
@@ -220,7 +221,8 @@ function BMButtonHandlers.ResolveButtonLabel(Button)
         end
     end
     evaluatedLabel = tostring(evaluatedLabel)
-    return evaluatedLabel:gsub(" ", "\n")
+
+    return leaveSpaces and evaluatedLabel or evaluatedLabel:gsub(" ", "\n")
 end
 
 ---@param Button table # BMButtonConfig

--- a/bmButtonHandlers.lua
+++ b/bmButtonHandlers.lua
@@ -245,7 +245,7 @@ function BMButtonHandlers.CalcButtonTextPos(Button, size)
     local label_x, label_y = ImGui.CalcTextSize(Button.CachedLabel)
     local midX, midY = math.max(math.floor((size - label_x) / 2), 0), math.floor((size - label_y) / 2)
     if midX ~= Button.labelMidX or midY ~= Button.labelMidY then
-        btnUtils.Debug("New Label Pos for %s : %d %d was %d %d", Button.CachedLabel:gsub("\n", " "), midX, midY, Button.labelMidX, Button.labelMidY)
+        btnUtils.Debug("New Label Pos for %s : %d %d was %d %d", Button.CachedLabel:gsub("\n", " "), midX, midY, Button.labelMidX or -1, Button.labelMidY or -1)
         Button.labelMidX, Button.labelMidY = midX, midY
     end
 end

--- a/bmButtonHandlers.lua
+++ b/bmButtonHandlers.lua
@@ -205,6 +205,9 @@ function BMButtonHandlers.RenderButtonLabel(Button, cursorScreenPos, size, label
     local buttonLabelCol = IM_COL32(tonumber(Colors[1]) or 255, tonumber(Colors[2]) or 255, tonumber(Colors[3]) or 255, 255)
     local draw_list = ImGui.GetWindowDrawList()
 
+    if btnUtils.enableDebug then
+        BMButtonHandlers.CalcButtonTextPos(Button, size)
+    end
     draw_list:PushClipRect(cursorScreenPos, ImVec2(cursorScreenPos.x + size, cursorScreenPos.y + size), true)
     draw_list:AddText(ImVec2(cursorScreenPos.x + (Button.labelMidX or 0), cursorScreenPos.y + (Button.labelMidY or 0)), buttonLabelCol, label)
     draw_list:PopClipRect()
@@ -238,11 +241,14 @@ function BMButtonHandlers.ResolveButtonLabel(Button, size, leaveSpaces, cacheUpd
 
     Button.CachedLabel = leaveSpaces and evaluatedLabel or evaluatedLabel:gsub(" ", "\n")
 
-    local label_x, label_y = ImGui.CalcTextSize(Button.CachedLabel)
-    Button.labelMidX = math.max((size - label_x) / 2, 0)
-    Button.labelMidY = (size - label_y) / 2
+    BMButtonHandlers.CalcButtonTextPos(Button, size)
 
     return Button.CachedLabel
+end
+
+function BMButtonHandlers.CalcButtonTextPos(Button, size)
+    local label_x, label_y = ImGui.CalcTextSize(Button.CachedLabel)
+    Button.labelMidX, Button.labelMidY = math.max((size - label_x) / 2, 0), (size - label_y) / 2
 end
 
 ---@param Button table # BMButtonConfig

--- a/bmButtonHandlers.lua
+++ b/bmButtonHandlers.lua
@@ -106,7 +106,7 @@ end
 ---@param cursorScreenPos table # cursor position on screen
 ---@param size number # button size
 function BMButtonHandlers.RenderButtonCooldown(Button, cursorScreenPos, size)
-    local countDown, coolDowntimer, toggleLocked = BMButtonHandlers.GetButtonCooldown(Button)
+    local countDown, coolDowntimer, toggleLocked = BMButtonHandlers.GetButtonCooldown(Button, true)
     if coolDowntimer == 0 and not toggleLocked then return end
 
     local ratio = 1 - (countDown / (coolDowntimer))
@@ -299,7 +299,6 @@ end
 
 function BMButtonHandlers.EvaluateAndCache(Button)
     BMButtonHandlers.ResolveButtonLabel(Button, false, true)
-    BMButtonHandlers.GetButtonCooldown(Button, true)
 end
 
 ---@param Button table # BMButtonConfig

--- a/bmHotbarClass.lua
+++ b/bmHotbarClass.lua
@@ -767,7 +767,7 @@ function BMHotbarClass:GiveTime()
 
     for i, set in ipairs(BMSettings:GetCharacterWindowSets(self.id)) do
         if self.currentSelectedSet == i then
-            btnUtils.Debug("Caching Visibile Buttons for Set: %s / %d", set, i)
+            --btnUtils.Debug("Caching Visibile Buttons for Set: %s / %d", set, i)
             local renderButtonCount = self.visibleButtonCount
 
             for ButtonIndex = 1, renderButtonCount do

--- a/bmHotbarClass.lua
+++ b/bmHotbarClass.lua
@@ -257,7 +257,6 @@ end
 
 function BMHotbarClass:RenderTabContextMenu()
     local openPopup = false
-    local btnSize = (BMSettings:GetCharacterWindow(self.id).ButtonSize or 6) * 10
 
     local unassigned = {}
     local charLoadedSets = {}
@@ -316,11 +315,11 @@ function BMHotbarClass:RenderTabContextMenu()
 
         if ImGui.BeginMenu("Delete Hotkey") then
             local sortedButtons = {}
-            for k, v in pairs(BMSettings:GetSettings().Buttons) do table.insert(sortedButtons, { Label = BMButtonHandlers.ResolveButtonLabel(v, btnSize, true), id = k, }) end
+            for k, v in pairs(BMSettings:GetSettings().Buttons) do table.insert(sortedButtons, { Label = BMButtonHandlers.ResolveButtonLabel(v, true), id = k, }) end
             table.sort(sortedButtons, function(a, b) return a.Label < b.Label end)
 
             for _, buttonData in pairs(sortedButtons) do
-                if ImGui.MenuItem(BMButtonHandlers.ResolveButtonLabel(buttonData, btnSize, true)) then
+                if ImGui.MenuItem(BMButtonHandlers.ResolveButtonLabel(buttonData, true)) then
                     -- clean up any references to this Button.
                     for setNameKey, setButtons in pairs(BMSettings:GetSettings().Sets) do
                         for buttonKey, buttonName in pairs(setButtons) do
@@ -509,7 +508,6 @@ end
 
 function BMHotbarClass:RenderContextMenu(Set, Index, buttonID)
     local button = BMSettings:GetButtonBySetIndex(Set, Index)
-    local btnSize = (BMSettings:GetCharacterWindow(self.id).ButtonSize or 6) * 10
 
     if ImGui.BeginPopupContextItem(buttonID) then
         local unassigned = {}
@@ -537,15 +535,15 @@ function BMHotbarClass:RenderContextMenu(Set, Index, buttonID)
 
                 -- Sort the keys based on the Label field
                 table.sort(sortedKeys, function(a, b)
-                    local labelA = unassigned[a] and BMButtonHandlers.ResolveButtonLabel(unassigned[a], btnSize, true)
-                    local labelB = unassigned[b] and BMButtonHandlers.ResolveButtonLabel(unassigned[b], btnSize, true)
+                    local labelA = unassigned[a] and BMButtonHandlers.ResolveButtonLabel(unassigned[a], true)
+                    local labelB = unassigned[b] and BMButtonHandlers.ResolveButtonLabel(unassigned[b], true)
                     return labelA < labelB
                 end)
 
                 for _, key in ipairs(sortedKeys) do
                     local value = unassigned[key]
                     if value ~= nil then
-                        if ImGui.MenuItem(BMButtonHandlers.ResolveButtonLabel(value, btnSize, true)) then
+                        if ImGui.MenuItem(BMButtonHandlers.ResolveButtonLabel(value, true)) then
                             BMSettings:GetSettings().Sets[Set][Index] = key
                             BMSettings:SaveSettings(true)
                             break
@@ -592,6 +590,7 @@ function BMHotbarClass:RenderButtons(Set)
 
     for ButtonIndex = 1, renderButtonCount do
         local button = BMSettings:GetButtonBySetIndex(Set, ButtonIndex)
+
         local clicked = false
 
         local buttonID = string.format("##Button_%s_%d", Set, ButtonIndex)
@@ -766,8 +765,6 @@ function BMHotbarClass:GiveTime()
     if now - self.lastFrameTime < fps then return end
     self.lastFrameTime = now
 
-    local btnSize = (BMSettings:GetCharacterWindow(self.id).ButtonSize or 6) * 10
-
     for i, set in ipairs(BMSettings:GetCharacterWindowSets(self.id)) do
         if self.currentSelectedSet == i then
             btnUtils.Debug("Caching Visibile Buttons for Set: %s / %d", set, i)
@@ -776,7 +773,7 @@ function BMHotbarClass:GiveTime()
             for ButtonIndex = 1, renderButtonCount do
                 local button = BMSettings:GetButtonBySetIndex(set, ButtonIndex)
 
-                BMButtonHandlers.EvaluateAndCache(button, btnSize)
+                BMButtonHandlers.EvaluateAndCache(button)
             end
         end
     end

--- a/bmHotbarClass.lua
+++ b/bmHotbarClass.lua
@@ -257,6 +257,7 @@ end
 
 function BMHotbarClass:RenderTabContextMenu()
     local openPopup = false
+    local btnSize = (BMSettings:GetCharacterWindow(self.id).ButtonSize or 6) * 10
 
     local unassigned = {}
     local charLoadedSets = {}
@@ -315,11 +316,11 @@ function BMHotbarClass:RenderTabContextMenu()
 
         if ImGui.BeginMenu("Delete Hotkey") then
             local sortedButtons = {}
-            for k, v in pairs(BMSettings:GetSettings().Buttons) do table.insert(sortedButtons, { Label = v.Label, id = k, }) end
+            for k, v in pairs(BMSettings:GetSettings().Buttons) do table.insert(sortedButtons, { Label = BMButtonHandlers.ResolveButtonLabel(v, btnSize, true), id = k, }) end
             table.sort(sortedButtons, function(a, b) return a.Label < b.Label end)
 
             for _, buttonData in pairs(sortedButtons) do
-                if ImGui.MenuItem(buttonData.Label) then
+                if ImGui.MenuItem(BMButtonHandlers.ResolveButtonLabel(buttonData, btnSize, true)) then
                     -- clean up any references to this Button.
                     for setNameKey, setButtons in pairs(BMSettings:GetSettings().Sets) do
                         for buttonKey, buttonName in pairs(setButtons) do

--- a/bmHotbarClass.lua
+++ b/bmHotbarClass.lua
@@ -474,15 +474,15 @@ function BMHotbarClass:RenderContextMenu(Set, Index, buttonID)
 
                 -- Sort the keys based on the Label field
                 table.sort(sortedKeys, function(a, b)
-                    local labelA = unassigned[a] and BMButtonHandlers.ResolveButtonLabel(unassigned[a])
-                    local labelB = unassigned[b] and BMButtonHandlers.ResolveButtonLabel(unassigned[b])
+                    local labelA = unassigned[a] and BMButtonHandlers.ResolveButtonLabel(unassigned[a], true)
+                    local labelB = unassigned[b] and BMButtonHandlers.ResolveButtonLabel(unassigned[b], true)
                     return labelA < labelB
                 end)
 
                 for _, key in ipairs(sortedKeys) do
                     local value = unassigned[key]
                     if value ~= nil then
-                        if ImGui.MenuItem(BMButtonHandlers.ResolveButtonLabel(value)) then
+                        if ImGui.MenuItem(BMButtonHandlers.ResolveButtonLabel(value, true)) then
                             BMSettings:GetSettings().Sets[Set][Index] = key
                             BMSettings:SaveSettings(true)
                             break

--- a/bmHotbarClass.lua
+++ b/bmHotbarClass.lua
@@ -474,15 +474,15 @@ function BMHotbarClass:RenderContextMenu(Set, Index, buttonID)
 
                 -- Sort the keys based on the Label field
                 table.sort(sortedKeys, function(a, b)
-                    local labelA = unassigned[a] and unassigned[a].Label
-                    local labelB = unassigned[b] and unassigned[b].Label
+                    local labelA = unassigned[a] and BMButtonHandlers.ResolveButtonLabel(unassigned[a])
+                    local labelB = unassigned[b] and BMButtonHandlers.ResolveButtonLabel(unassigned[b])
                     return labelA < labelB
                 end)
 
                 for _, key in ipairs(sortedKeys) do
                     local value = unassigned[key]
                     if value ~= nil then
-                        if ImGui.MenuItem(tostring(value.Label)) then
+                        if ImGui.MenuItem(BMButtonHandlers.ResolveButtonLabel(value)) then
                             BMSettings:GetSettings().Sets[Set][Index] = key
                             BMSettings:SaveSettings(true)
                             break

--- a/bmHotbarClass.lua
+++ b/bmHotbarClass.lua
@@ -135,6 +135,9 @@ function BMHotbarClass:RenderHotbar(flags)
     if self.openGUI ~= self:IsVisible() then
         self:SetVisible(self.openGUI)
         self.openGUI = true
+        if not self:IsVisible() then
+            btnUtils.Output("Hotbar %d hidden! Use `/btn %d` to bring it back.", self.id, self.id)
+        end
     end
 end
 

--- a/bmSettings.lua
+++ b/bmSettings.lua
@@ -1,7 +1,9 @@
-local mq                        = require('mq')
-local btnUtils                  = require('lib.buttonUtils')
+local mq            = require('mq')
+local btnUtils      = require('lib.buttonUtils')
 
-local settings_path             = mq.configDir .. '/ButtonMaster.lua'
+local settings_base = mq.configDir .. '/ButtonMaster'
+local settings_path = settings_base .. '.lua '
+
 
 local BMSettings                = {}
 BMSettings.__index              = BMSettings
@@ -29,6 +31,11 @@ end
 
 function BMSettings:SaveSettings(doBroadcast)
     if doBroadcast == nil then doBroadcast = true end
+
+    if not self.settings.LastBackup or os.time() - self.settings.LastBackup > 3600 * 24 then
+        self.settings.LastBackup = os.time()
+        mq.pickle(mq.configDir .. "/Buttonmaster-Backups/ButtonMaster-backup-" .. os.date("%m-%d-%y-%H-%M-%S") .. ".lua", self.settings)
+    end
 
     mq.pickle(settings_path, self.settings)
 

--- a/init.lua
+++ b/init.lua
@@ -88,7 +88,9 @@ local function GiveTime()
 
         if #BMHotbars > 0 then
             for _, bmHB in ipairs(BMHotbars) do
-                bmHB:GiveTime()
+                if bmHB:IsVisible() then
+                    bmHB:GiveTime()
+                end
             end
         end
     end

--- a/init.lua
+++ b/init.lua
@@ -85,6 +85,12 @@ local function GiveTime()
             reloadSettings = false
             BMSettings:LoadSettings()
         end
+
+        if #BMHotbars > 0 then
+            for _, bmHB in ipairs(BMHotbars) do
+                bmHB:GiveTime()
+            end
+        end
     end
     btnUtils.Output('\arNot in game, stopping button master.\ax')
 end

--- a/lib/IconPicker.lua
+++ b/lib/IconPicker.lua
@@ -57,6 +57,7 @@ function IconPicker:RenderTab(getterFn, maxIcon)
     local cols = math.max(math.floor(width / (IconSize + style.ItemSpacing.x)), 1)
     local maxPage = math.ceil(maxIcon / self.iconsPerPage)
     if self.Page > maxPage then self.Page = maxPage end
+    ImGui.BeginChild("Icon##Picker")
     if ImGui.BeginTable("SpellIcons", cols) then
         local startId = math.max(0, ((self.Page - 1) * self.iconsPerPage))
         local endId   = math.min(maxIcon, startId + self.iconsPerPage - 1)
@@ -65,6 +66,7 @@ function IconPicker:RenderTab(getterFn, maxIcon)
             getterFn(self, iconId)
         end
         ImGui.EndTable()
+        ImGui.EndChild()
     end
 end
 


### PR DESCRIPTION
made the contents of the tabs on the icon picker a child so they can scroll independently of the window. 

This allows the page info to stay at the top of the screen.