### PR TITLE
support disc timers for buttons

### DIFF
--- a/bmButtonHandlers.lua
+++ b/bmButtonHandlers.lua
@@ -96,6 +96,9 @@ function BMButtonHandlers.GetButtonCooldown(Button, cacheUpdate)
     elseif Button.TimerType == "AA" then
         Button.CachedCountDown = (mq.TLO.Me.AltAbilityTimer(Button.Cooldown)() or 0) / 1000
         Button.CachedCoolDownTimer = mq.TLO.Me.AltAbility(Button.Cooldown).MyReuseTime() or 0
+    elseif Button.TimerType == "Disc" then
+        Button.CachedCountDown = mq.TLO.Me.CombatAbilityTimer(Button.Cooldown).TotalSeconds() or 0
+        Button.CachedCoolDownTimer = (mq.TLO.Spell(Button.Cooldown).RecastTime() or 0) / 1000
     elseif Button.TimerType == "Ability" then
         if mq.TLO.Me.AbilityTimer and mq.TLO.Me.AbilityTimerTotal then
             Button.CachedCountDown = (mq.TLO.Me.AbilityTimer(Button.Cooldown)() or 0) / 1000

--- a/bmEditButtonPopup.lua
+++ b/bmEditButtonPopup.lua
@@ -61,6 +61,13 @@ function BMButtonEditor:RenderEditButtonPopup()
                     self.tmpButton.Icon = nil
                     self.tmpButton.Cooldown = buttonText
                     self.tmpButton.TimerType = "Ability"
+                elseif attachmentType == "melee_ability" then
+                    self.tmpButton.Label = buttonText
+                    self.tmpButton.Cmd = string.format("/disc %s", buttonText)
+                    self.tmpButton.Icon = mq.TLO.Spell(buttonText).SpellIcon()
+                    self.tmpButton.IconType = "Spell"
+                    self.tmpButton.Cooldown = buttonText
+                    self.tmpButton.TimerType = "Disc"
                 elseif attachmentType == "social" then
                     self.tmpButton.Label = buttonText
                     if cursorIndex >= 120 then
@@ -284,6 +291,9 @@ function BMButtonEditor:RenderTimerPanel(renderButton)
     elseif BMSettings.Constants.TimerTypes[self.selectedTimerType] == "Ability" then
         renderButton.Cooldown = ImGui.InputText("Ability Name", tostring(renderButton.Cooldown))
         btnUtils.Tooltip("Name of the Ability that you want to track the cooldown of.")
+    elseif BMSettings.Constants.TimerTypes[self.selectedTimerType] == "Disc" then
+        renderButton.Cooldown = ImGui.InputText("Disc Name", tostring(renderButton.Cooldown))
+        btnUtils.Tooltip("Name of the Disc that you want to track the cooldown of.")
     end
 end
 

--- a/bmSettings.lua
+++ b/bmSettings.lua
@@ -20,6 +20,7 @@ BMSettings.Constants.TimerTypes = {
     "Spell Gem",
     "AA",
     "Ability",
+    "Disc",
     "Custom Lua",
 }
 


### PR DESCRIPTION
I'm not sure what the value of CursorAttachment.Index is when the attachment is of type MELEE_ABILITY (combat discs), so I didn't use it. Just used button text instead.
Not sure if there will be cases where a disc hotkey created from disc window doesn't have a name that matches propertly to the full disc name like with rank and stuff, so might need to figure out how to get it properly from the attachment.