### PR TITLE
add an update rate configurable per button

### DIFF
--- a/bmButtonHandlers.lua
+++ b/bmButtonHandlers.lua
@@ -43,6 +43,7 @@ function BMButtonHandlers.GetButtonCooldown(Button, cacheUpdate)
     Button.CachedCountDown     = 0
     Button.CachedCoolDownTimer = 0
     Button.CachedToggleLocked  = false
+	Button.CachedLastRan       = BMButtonHandlers.GetTimeMS()
 
     if Button.TimerType == "Custom Lua" then
         local success
@@ -113,8 +114,31 @@ end
 ---@param cursorScreenPos table # cursor position on screen
 ---@param size number # button size
 function BMButtonHandlers.RenderButtonCooldown(Button, cursorScreenPos, size)
-    local countDown, coolDowntimer, toggleLocked = BMButtonHandlers.GetButtonCooldown(Button, true)
-    if coolDowntimer == 0 and not toggleLocked then return end
+    
+	local currentTimer = BMButtonHandlers.GetTimeMS()
+    local updateRate =0
+
+    if Button.UpdateRate ~=nil then
+        --this button has a defined rate
+        if Button.UpdateRate == "Unlimited" then
+            updateRate=0
+        elseif Button.UpdateRate =="1 per second" then
+            updateRate=1
+        elseif Button.UpdateRate == "2 per second" then
+            updateRate=0.5
+        elseif Button.UpdateRate == "4 per second" then
+            updateRate=0.25
+        elseif Button.UpdateRate == "10 per second" then
+            updateRate=0.1
+        elseif Button.UpdateRate == "20 per second" then
+            updateRate=0.05
+        end
+    end
+
+	local updateCache = (Button.CachedLastRan == nil or ((currentTimer - Button.CachedLastRan) > updateRate) or ((currentTimer - Button.CachedLastRan)<0))
+	local countDown, coolDowntimer, toggleLocked = BMButtonHandlers.GetButtonCooldown(Button, updateCache)
+	
+	if coolDowntimer == 0 and not toggleLocked then return end
 
     local ratio = 1 - (countDown / (coolDowntimer))
 

--- a/bmEditButtonPopup.lua
+++ b/bmEditButtonPopup.lua
@@ -15,6 +15,7 @@ BMButtonEditor.editButtonUIChanged = false
 BMButtonEditor.tmpButton           = nil
 
 BMButtonEditor.selectedTimerType   = 1
+BMButtonEditor.selectedUpdateRate = 1
 
 function BMButtonEditor:RenderEditButtonPopup()
     if not self.editButtonPopupOpen then
@@ -146,6 +147,7 @@ function BMButtonEditor:OpenEditPopup(Set, Index)
     self.editButtonIndex = Index
     self.editButtonSet = Set
     self.selectedTimerType = 1
+    self.selectedUpdateRate = 1
     local button = BMSettings:GetButtonBySetIndex(Set, Index)
     self.tmpButton = btnUtils.shallowcopy(button)
 
@@ -153,6 +155,12 @@ function BMButtonEditor:OpenEditPopup(Set, Index)
         for index, type in ipairs(BMSettings.Constants.TimerTypes) do
             if type == button.TimerType then
                 self.selectedTimerType = index
+                break
+            end
+        end
+        for index, type in ipairs(BMSettings.Constants.UpdateRates) do
+            if type == button.UpdateRate then
+                self.selectedUpdateRate = index
                 break
             end
         end
@@ -238,6 +246,9 @@ function BMButtonEditor:RenderButtonEditUI(renderButton, enableShare, enableEdit
         renderButton.IconLua, textChanged = ImGui.InputText('Icon Lua', renderButton.IconLua or '')
         btnUtils.Tooltip(
             "Dynamically override the IconID with this Lua function. \nNote: This MUST return number, string : IconId, IconType")
+        
+        self.selectedUpdateRate, _ = ImGui.Combo("Update Rate", self.selectedUpdateRate, BMSettings.Constants.UpdateRates)
+        renderButton.UpdateRate = BMSettings.Constants.UpdateRates[self.selectedUpdateRate]
         self.editButtonUIChanged = self.editButtonUIChanged or textChanged
     end
 

--- a/bmSettings.lua
+++ b/bmSettings.lua
@@ -24,6 +24,16 @@ BMSettings.Constants.TimerTypes = {
     "Custom Lua",
 }
 
+BMSettings.Constants.UpdateRates = {
+    "Unlimited",
+    "1 per second",
+    "2 per second",
+    "4 per second",
+    "10 per second",
+    "20 per second",
+}
+
+
 function BMSettings.new()
     local newSettings      = setmetatable({}, BMSettings)
     newSettings.CharConfig = string.format("%s_%s", mq.TLO.EverQuest.Server(), mq.TLO.Me.DisplayName())


### PR DESCRIPTION
add an update rate configurable per button, this is found in the advanced settings of each button.

unlimited is default (your FPS rate), tho for *most* buttons your dealing with things that don't need quite that high of rate (anything over 15-30 seconds basically).

Note limited testing shows that it is functional (at least on my machine), further testing is suggested.
