### PR TITLE
Fix for crash when picking icons

### DIFF
--- a/lib/IconPicker.lua
+++ b/lib/IconPicker.lua
@@ -88,6 +88,7 @@ function IconPicker:RenderIconPicker()
                 self:RenderTab(self.renderItemIcon, self.maxItem)
                 ImGui.EndTabItem()
             end
+            ImGui.EndTabBar()
         end
     end
     ImGui.End()


### PR DESCRIPTION
* Missing EndTabBar() in IconPicker